### PR TITLE
Move console.profile() example code inside

### DIFF
--- a/[DEV]-Perf-Tools-for-VS-Code-Development.md
+++ b/[DEV]-Perf-Tools-for-VS-Code-Development.md
@@ -69,16 +69,17 @@ Know that you can use `console.profile` and `console.profileEnd` to profile just
 * Have and execute code like below
 * The JavaScript Profiler tab will be populated with the profiles
 
-### Profile Startup
-
-You can start VS Code with a `--prof-startup` flag and it will automatically capture a profile of the main, renderer, and extension host process. Once it is done it asks you to restart and stores the files in your home directory. This is great to analyse the whole startup, esp of the built product. 
-
-
 ```ts
 console.profile('Hi');
 // some code that you want to drill into
 console.profileEnd('Hi');
 ```
+
+
+### Profile Startup
+
+You can start VS Code with a `--prof-startup` flag and it will automatically capture a profile of the main, renderer, and extension host process. Once it is done it asks you to restart and stores the files in your home directory. This is great to analyse the whole startup, esp of the built product. 
+
 
 ### Delayed Services
 


### PR DESCRIPTION
This PR just moves the `console.profile()` example code inside the section that references it.